### PR TITLE
Set timeout to 90 seconds.

### DIFF
--- a/lib/user_stream/api.rb
+++ b/lib/user_stream/api.rb
@@ -37,7 +37,7 @@ module UserStream
 
     # Create a new consumer
     def consumer
-      OAuth::Consumer.new(consumer_key, consumer_secret, :site => endpoint)
+      OAuth::Consumer.new(consumer_key, consumer_secret, :site => endpoint, :timeout => 90)
     end
 
     # Create a new access token


### PR DESCRIPTION
イベントの少ないアカウントや深夜帯などで時々 `Timeout::Error` が発生しているので、[Twitter のドキュメント](https://dev.twitter.com/docs/streaming-apis/connecting#Stalls) に従って 90 秒のタイムアウトを設定しました。ご検討お願い致します。
