### PR TITLE
Update API endpoint URLs

### DIFF
--- a/lib/user_stream/client.rb
+++ b/lib/user_stream/client.rb
@@ -6,21 +6,21 @@ module UserStream
     #
     # @see https://dev.twitter.com/docs/streaming-api/user-streams
     def user(params = {}, &block)
-      post('/2/user.json', params, &block)
+      post('/1.1/user.json', params, &block)
     end
 
     # Process public statuses that match one or more filter predicates by given block
     #
     # @see https://dev.twitter.com/docs/streaming-api/methods#statuses-filter
     def filter(params = {}, &block)
-      post('/1/statuses/filter.json', params, &block)
+      post('/1.1/statuses/filter.json', params, &block)
     end
 
     # Process a random sample of all public statuses by given block
     #
     # @see https://dev.twitter.com/docs/streaming-api/methods#statuses-sample
     def sample(params = {}, &block)
-      get('/1/statuses/sample.json', params, &block)
+      get('/1.1/statuses/sample.json', params, &block)
     end
   end
 end


### PR DESCRIPTION
Twitter API v1.1ではStreaming APIも含めてURLが変わるようです。
よろしくお願いします。

https://dev.twitter.com/docs/api/1.1/get/user
